### PR TITLE
Potential fix for code scanning alert no. 26: DOM text reinterpreted as HTML

### DIFF
--- a/templates/web_maker/edit.html
+++ b/templates/web_maker/edit.html
@@ -349,7 +349,9 @@
         if (hyperLink.includes(cshow.tagName.toLowerCase())) {
             var href = $('#href').val().trim();
             // Only allow http, https, and mailto schemes (case-insensitive)
-            if (!/^((https?|mailto):\/\/)/i.test(href)) {
+            var isHttp = /^https?:\/\/.+/i.test(href);
+            var isMailto = /^mailto:[^@]+@[^@]+\.[^@]+$/i.test(href);
+            if (!(isHttp || isMailto)) {
                 // Bad uri
                 cshow.href = "#禁止使用的地址#";
             } else {

--- a/templates/web_maker/edit.html
+++ b/templates/web_maker/edit.html
@@ -347,12 +347,13 @@
             cshow.innerText = $('#text').val();
         }
         if (hyperLink.includes(cshow.tagName.toLowerCase())) {
-            var href = $('#href').val();
-            if((!href.startsWith('http://') && !href.startsWith('https://')) && (href.indexOf(":")!=-1)) {
+            var href = $('#href').val().trim();
+            // Only allow http, https, and mailto schemes (case-insensitive)
+            if (!/^((https?|mailto):\/\/)/i.test(href)) {
                 // Bad uri
                 cshow.href = "#禁止使用的地址#";
-            }else{
-                cshow.href = $('#href').val();
+            } else {
+                cshow.href = href;
             }
             cshow.innerText = $('#link_text').val();
         }


### PR DESCRIPTION
Potential fix for [https://github.com/apkqiu/availability/security/code-scanning/26](https://github.com/apkqiu/availability/security/code-scanning/26)

To fix the problem, we need to ensure that the value assigned to the `href` property is safe and cannot be used to inject malicious URIs. The best way is to:

- Strictly validate the input to allow only safe URL schemes (e.g., `http://`, `https://`, and optionally `mailto:`).
- Reject or sanitize any other input, including those with encoded or obfuscated schemes.
- Use a regular expression to match allowed schemes in a case-insensitive manner and trim whitespace.
- Apply this validation in the region where the `href` is set (lines 350-356).

No new imports are needed, as this can be done with standard JavaScript.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
